### PR TITLE
Added type-safe `Endpoint`

### DIFF
--- a/Sources/DiscourseKit/API/DKClient+Categories.swift
+++ b/Sources/DiscourseKit/API/DKClient+Categories.swift
@@ -66,7 +66,7 @@ public extension DKClient {
         }
         
         // Get the category, cache it, return it
-        self.get(from: .category, pathParams: String(id)) { parser in
+        self.get(from: .category(for: id)) { parser in
             let result = parser.decodeResponse(Category.self, "category")
             self.cache(category: try? result.get())
             completion(result)
@@ -75,10 +75,10 @@ public extension DKClient {
     
     private func cache(category cat: Category?) {
         guard let cat = cat else { return }
-        self.encache(.category, key: cat.id, value: cat)
+        self.encache(.category(for: cat.id), key: cat.id, value: cat)
     }
     
     private func cachedCategory(with id: Int) -> Category? {
-        return self.check(cache: .category, key: id)
+        return self.check(cache: .category(for: id), key: id)
     }
 }

--- a/Sources/DiscourseKit/API/DKClient+Comments.swift
+++ b/Sources/DiscourseKit/API/DKClient+Comments.swift
@@ -16,7 +16,7 @@ public extension DKClient {
     }
 
     func comment(with id: Int, completion: @escaping DKResponseBlock<Comment>) {
-        self.get(from: .comment, pathParams: id.description) { parser in
+        self.get(from: .comment(for: id)) { parser in
             completion(parser.decodeResponse())
         }
     }

--- a/Sources/DiscourseKit/API/DKClient+Feed.swift
+++ b/Sources/DiscourseKit/API/DKClient+Feed.swift
@@ -15,7 +15,7 @@ public extension DKClient {
             let topicList: Listing
         }
 
-        self.get(from: .feed, pathParams: sort.path) { parser in
+        self.get(from: .feed(for: sort.path)) { parser in
             let result: Result<FeedResponse,DKCodingError> = parser.decodeResponse()
             completion(result.map { feed in
                 // Take `users` and use it to populate the `author`

--- a/Sources/DiscourseKit/API/DKClient.swift
+++ b/Sources/DiscourseKit/API/DKClient.swift
@@ -74,15 +74,15 @@ public class DKClient {
     /// }
     /// ```
     /// The resulting URL might look something like: `https://example.org/pitches/new?ascending=0`
-    func get(_ query: Query? = nil, from endpoint: Endpoint, pathParams: String..., callback: @escaping ResponseParserBlock) {
-        self.get({ self.configure($0, query, endpoint, pathParams, false) }, callback: callback)
+    func get(_ query: Query? = nil, from endpoint: Endpoint, callback: @escaping ResponseParserBlock) {
+        self.get({ self.configure($0, query, endpoint, false) }, callback: callback)
     }
     
     /// For POST requests.
     /// 
     /// Behaves like `get(_:from:pathParams:callback)`, but the given query is sent as a part of the HTTP body.
-    func post(_ query: Query? = nil, to endpoint: Endpoint, pathParams: String..., callback: @escaping ResponseParserBlock) {
-        self.post({ self.configure($0, query, endpoint, pathParams, true) }, callback: callback)
+    func post(_ query: Query? = nil, to endpoint: Endpoint, callback: @escaping ResponseParserBlock) {
+        self.post({ self.configure($0, query, endpoint, true) }, callback: callback)
     }
     
     /// Executes the given callback with any error found.
@@ -134,18 +134,14 @@ public class DKClient {
     /// setting **the endpoint** or applying any **query or path parameters.**
     ///
     /// TODO: this should be an extension on URLRequestBuilder instead
-    func configure(_ make: URLRequestBuilder, _ query: Query?, _ endpoint: Endpoint, _ pathParams: [String], _ useBody: Bool) {
-        // Construct the endpoint if given a path parameter. For example, given an
-        // endpoint "/user/%@" and path "mxcl", this would produce "/user/mxcl"
-        let ep = endpoint.make(pathParams)
-        
+    func configure(_ make: URLRequestBuilder, _ query: Query?, _ endpoint: Endpoint, _ useBody: Bool) {
         // Gather the parameters and decide which format to send them in;
         // POST requests use the body instead of standard queries
         let format: URLRequestBuilder.ParamFormat = useBody ? .bodyJSON : .query
         let params = (query ?? [:]) + self.defaultQueryParams
         
         // Assign the endpoint and pass any parameters
-        make.endpoint(ep).params(params, format: format)
+        make.endpoint(endpoint.rawValue).params(params, format: format)
     }
     
     /// This is a chance for API-specific code to run once a request has finished.

--- a/Sources/Networking/Endpoints.swift
+++ b/Sources/Networking/Endpoints.swift
@@ -9,37 +9,25 @@
 import Foundation
 
 /// Discourse API endpoints.
-///
-/// Each endpoint is a string that may or may not have
-/// path parameters. If an endpoint *does* have path
-/// parameters, you must call `make(_:)` with the
-/// parameters to generate the fully fully-formed endpoint.
-public enum Endpoint: String {
+public struct Endpoint: RawRepresentable, Hashable {
+    public init(rawValue: String) { self.rawValue = rawValue }
+    public let rawValue: String
     
-    case preAuth = "/session/csrf"
-    case login = "/session"
-    case search = "/search"
+    public static let preAuth: Self = .init(rawValue: "/session/csrf")
+    public static let login: Self = .init(rawValue: "/session")
+    public static let search: Self = .init(rawValue: "/search")
     
-    case comments = "/posts.json"
-    case comment = "/posts/%@.json"
-
-    case feed = "/%@.json"
+    public static let comments: Self = .init(rawValue: "/posts.json")
+    public static func comment(for id: Int) -> Self {
+        .init(rawValue: "/posts/\(id).json")
+    }
     
-    case categories = "/categories.json"
-    case category = "/c/%@/show.json"
+    public static func feed(for id: String) -> Self {
+        .init(rawValue: "/\(id).json")
+    }
     
-    /// Takes a list of path parameters and
-    /// builds a fully-formed endpoint.
-    ///
-    /// Ideally, we would be able to dynamically get a list
-    /// of an enum case's associated values and build the
-    /// string by hand, so that it remains totally type-safe
-    /// and free of case-by-case boilerplate. Perhaps in the future.
-    public func make(_ args: [String]) -> String {
-        if args.isEmpty {
-            return self.rawValue
-        } else {
-            return String(format: self.rawValue, arguments: args)
-        }
+    public static let categories: Self = .init(rawValue: "/categories.json")
+    public static func category(for id: Int) -> Self {
+        .init(rawValue: "/c/\(id)/show.json")
     }
 }

--- a/Sources/Networking/Endpoints.swift
+++ b/Sources/Networking/Endpoints.swift
@@ -9,15 +9,17 @@
 import Foundation
 
 /// Discourse API endpoints.
-public struct Endpoint: RawRepresentable, Hashable {
-    public init(rawValue: String) { self.rawValue = rawValue }
+public struct Endpoint: Hashable, RawRepresentable, ExpressibleByStringLiteral {
     public let rawValue: String
     
-    public static let preAuth: Self = .init(rawValue: "/session/csrf")
-    public static let login: Self = .init(rawValue: "/session")
-    public static let search: Self = .init(rawValue: "/search")
+    public init(rawValue: String) { self.rawValue = rawValue }
+    public init(stringLiteral value: String) { self.init(rawValue: value) }
+
+    public static let preAuth: Self = "/session/csrf"
+    public static let login: Self = "/session"
+    public static let search: Self = "/search"
     
-    public static let comments: Self = .init(rawValue: "/posts.json")
+    public static let comments: Self = "/posts.json"
     public static func comment(for id: Int) -> Self {
         .init(rawValue: "/posts/\(id).json")
     }
@@ -26,7 +28,7 @@ public struct Endpoint: RawRepresentable, Hashable {
         .init(rawValue: "/\(id).json")
     }
     
-    public static let categories: Self = .init(rawValue: "/categories.json")
+    public static let categories: Self = "/categories.json"
     public static func category(for id: Int) -> Self {
         .init(rawValue: "/c/\(id)/show.json")
     }


### PR DESCRIPTION
Created Endpoint as a RawRepresentable struct so that you can build type-safe endpoints. See more discussion around proper uses for enums vs structs with static members here: https://twitter.com/mergesort/status/1391030294803849216